### PR TITLE
Add: Intro영역 레이아웃 1차 완료

### DIFF
--- a/public/data/IntroData.json
+++ b/public/data/IntroData.json
@@ -1,13 +1,11 @@
-[
-  {
-    "posion": "Front-end Developer",
-    "title": "DAN:D",
-    "firstLine": "단디하는 프론트엔드 개발자 강단입니다.",
-    "hoveredText": " 단디하다. 헐겁거나 느슨하지 아니하고 튼튼하게 뜻하는 경상도 방언입니다. ",
-    "secondLine": "보여드리고 싶어요.",
-    "thirdLine": [
-      "탄탄한 코드 위에 유연하게 동작하는 UI를.",
-      "지속적으로 관리되며 발전 할 수 있는 UI를."
-    ]
-  }
-]
+{
+  "position": "Front-end Developer",
+  "title": "DAN:D",
+  "firstLine": ["단디", "하는 프론트엔드 개발자 ", "강단", "입니다."],
+  "remark": "단디하다. 헐겁거나 느슨하지 아니하고 튼튼하게 뜻하는 경상도 방언입니다. ",
+  "secondLine": "보여드리고 싶어요.",
+  "thirdLine": [
+    "탄탄한 코드 위에 유연하게 동작하는 UI를. ",
+    "지속적으로 관리되며 발전 할 수 있는 UI를."
+  ]
+}

--- a/src/Router.js
+++ b/src/Router.js
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import Main from './pages/Main/Main';
+import Main from './pages/Main';
+import TopButton from './components/Button/TopButton';
 
 export default function Router() {
   return (
@@ -7,6 +8,7 @@ export default function Router() {
       <Routes>
         <Route path="/" element={<Main />} />
       </Routes>
+      <TopButton />
     </BrowserRouter>
   );
 }

--- a/src/components/Button/TopButton/TopButton.js
+++ b/src/components/Button/TopButton/TopButton.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+export default function TopButton() {
+  return (
+    <TopButtonWrap>
+      <p className="text">Scroll</p>
+      <p className="line" />
+    </TopButtonWrap>
+  );
+}
+
+const upDown = keyframes`
+    0%{
+      opacity:0;
+      width:100%;
+    }
+    100% {
+      opacity:1;
+      width:0;
+    }
+`;
+
+const TopButtonWrap = styled.div`
+  position: fixed;
+  right: 50%;
+  margin-right: -500px;
+  bottom: 90px;
+  width: 80px;
+  height: 20px;
+  cursor: pointer;
+  transform: rotate(270deg);
+
+  &:hover > p.text {
+    opacity: 0.7;
+  }
+
+  p.text {
+    height: 100%;
+    padding-top: 6px;
+    text-align: right;
+    font-size: 13px;
+    letter-spacing: 2px;
+  }
+
+  p.line {
+    position: relative;
+    width: 100%;
+    height: 1px;
+    background: #8a8a8a;
+
+    &:before {
+      position: absolute;
+      top: 0;
+      left: 0;
+      content: '';
+      width: 20px;
+      height: 1px;
+      background: #8a8a8a;
+      transform-origin: bottom left;
+      transform: rotate(310deg);
+    }
+    &:after {
+      position: absolute;
+      top: 0;
+      left: 0;
+      content: '';
+      width: 100%;
+      height: 2px;
+      background: #fff;
+      animation-duration: 3000ms;
+      animation-timing-function: ease-in;
+      animation-name: ${upDown};
+      animation-iteration-count: infinite;
+    }
+  }
+`;

--- a/src/components/Button/TopButton/index.js
+++ b/src/components/Button/TopButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './TopButton';

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import styled from 'styled-components';
+import {
+  sectionTitleFont,
+  defaultFontStyle,
+  defaultFontSize,
+} from './../../styles/mixin';
+
+export default function Layout() {
+  return (
+    <LayoutWrap>
+      <SectionTitle>Skills</SectionTitle>
+      <Text>단디하는 프론트엔드 개발자 강단입니다.</Text>
+    </LayoutWrap>
+  );
+}
+const LayoutWrap = styled.section`
+  width: 1000px;
+  margin: 440px auto 0;
+`;
+const SectionTitle = styled.h3`
+  ${sectionTitleFont}
+`;
+
+const Text = styled.p`
+  ${defaultFontStyle}
+  ${defaultFontSize}
+`;

--- a/src/pages/Main/Intro/Intro.js
+++ b/src/pages/Main/Intro/Intro.js
@@ -1,41 +1,88 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import {
   mainTitleFont,
   subTitleFont,
-  sectionTitleFont,
-  defaultFont,
-} from './../../../styles/mixin';
+  defaultFontStyle,
+  defaultFontSize,
+  smallFontSize,
+} from '../../../styles/mixin';
 
 export default function Intro() {
+  const [introContents, setIntroContents] = useState({});
+
+  useEffect(() => {
+    fetch(`/data/introData.json`)
+      .then(data => data.json())
+      .then(data => setIntroContents(data));
+  }, []);
+
   return (
     <IntroWrap>
-      <SubTitle>Frond-end Developer</SubTitle>
-      <IntroTitle>DAN:D</IntroTitle>
-      <SectionTitle>Projects</SectionTitle>
-      <IntroDiscriotion>
-        단디하는 프론트엔드 개발자 강단입니다.
-      </IntroDiscriotion>
+      <SubTitle>{introContents.position}</SubTitle>
+      <IntroTitle>{introContents.title}</IntroTitle>
+
+      {introContents.firstLine &&
+        introContents.firstLine.map(idx => {
+          return <IntroMainDiscriotion key={idx}>{idx}</IntroMainDiscriotion>;
+        })}
+
+      <Remark className="remark">{introContents.remark}</Remark>
+      <IntroSubDiscriotion className="introDiscriotion">
+        {introContents.secondLine}
+      </IntroSubDiscriotion>
+      <IntroSubDiscriotion>
+        {introContents.thirdLine &&
+          introContents.thirdLine.map(idx => {
+            return <span key={idx}>{idx}</span>;
+          })}
+      </IntroSubDiscriotion>
     </IntroWrap>
   );
 }
+
 const IntroWrap = styled.section`
   width: 1000px;
-  margin: 440px auto 0;
+  margin: 400px auto 0;
 `;
 
 const IntroTitle = styled.h1`
   ${mainTitleFont}
+  text-indent: -7px;
 `;
 
 const SubTitle = styled.h2`
   ${subTitleFont}
 `;
 
-const SectionTitle = styled.h3`
-  ${sectionTitleFont}
+const IntroMainDiscriotion = styled.span`
+  ${defaultFontStyle};
+  ${defaultFontSize};
+  cursor: pointer;
+
+  &:nth-child(odd) {
+    font-weight: 600;
+  }
+  &:hover ~ p.remark {
+    color: #acacac;
+    transition: all 0.8s;
+    text-indent: 13px;
+  }
+  &:hover ~ p.introDiscriotion {
+    margin-top: 20px;
+    transition: all 0.3s;
+  }
 `;
 
-const IntroDiscriotion = styled.p`
-  ${defaultFont}
+const IntroSubDiscriotion = styled.p`
+  ${defaultFontStyle};
+  ${defaultFontSize};
+`;
+
+const Remark = styled.p`
+  height: 0;
+  ${defaultFontStyle};
+  ${smallFontSize};
+  color: #fff;
+  text-indent: -10px;
 `;

--- a/src/pages/Main/Intro/index.js
+++ b/src/pages/Main/Intro/index.js
@@ -1,0 +1,1 @@
+export { default } from './Intro';

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import Intro from './Intro/Intro';
+import Intro from './Intro';
 import Skills from './Skills/Skills';
 import SubSkills from './SubSkills/SubSkills';
 import LearningLog from './LearningLog/LearningLog';

--- a/src/pages/Main/Skills/Skills.js
+++ b/src/pages/Main/Skills/Skills.js
@@ -1,5 +1,10 @@
 import React from 'react';
+import Layout from '../../../components/Layout/Layout';
 
 export default function Skills() {
-  return <div>Skills</div>;
+  return (
+    <Layout>
+      <div>Skills</div>
+    </Layout>
+  );
 }

--- a/src/pages/Main/index.js
+++ b/src/pages/Main/index.js
@@ -1,0 +1,1 @@
+export { default } from './Main';

--- a/src/styles/mixin.js
+++ b/src/styles/mixin.js
@@ -2,13 +2,15 @@ import { css } from 'styled-components';
 
 export const mainTitleFont = css`
   font-family: 'Rozha One', serif;
-  font-size: 13em;
-  line-height: 125px;
+  font-size: 15em;
+  line-height: 140px;
+  margin-bottom: 15px;
 `;
 
 export const subTitleFont = css`
   font-family: 'Rozha One', serif;
-  font-size: 3em;
+  font-size: 3.5em;
+  letter-spacing: 0.11em;
 `;
 
 export const sectionTitleFont = css`
@@ -17,9 +19,16 @@ export const sectionTitleFont = css`
   color: transparent;
   -webkit-text-stroke: 1px #000;
 `;
+export const defaultFontStyle = css`
+  font-family: 'Noto Sans KR', sans-serif;
+  font-weight: 300;
+  line-height: 1.5;
+`;
 
-export const defaultFont = css`
-  /* font-family: 'Noto Sans KR', sans-serif;
-  font-weight: 300; */
+export const defaultFontSize = css`
   font-size: 16px;
+`;
+
+export const smallFontSize = css`
+  font-size: 13px;
 `;


### PR DESCRIPTION
## :: 구현 목표 
- Intro영역 레이아웃 구성

<br />

## :: 구현 사항
1. Intro영역 레이아웃 구성
- useEffect의 fetch연습을 위한 json파일에 mock data로 작성하여 사용

2. 공용 컨포넌트 - Scroll 버튼 레이아웃
- keyframe을 활용해 애니메이션 적용


